### PR TITLE
Add bumpversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fast Autocomplete 0.2.9
+# Fast Autocomplete 0.4.0
 
 Fast autocomplete using Directed Word Graph (DWG) and Levenshtein Edit Distance.
 
@@ -291,6 +291,15 @@ demo(autocomplete, max_cost=3, size=5)
 
 We try to maintain high standard in code coverage. Currently the `dwg` module's coverage is around 99%!
 
+## Releases
+
+We use bump2version to bump and tag releases.
+
+```bash
+git checkout master && git pull
+bump2version {patch|minor|major}
+git push && git push --tags
+```
 
 # Authors
 

--- a/fast_autocomplete/__init__.py
+++ b/fast_autocomplete/__init__.py
@@ -1,9 +1,12 @@
 # flake8: noqa
-__version__ = '0.4.0'
 import sys
+import pkg_resources
+
 pyversion = float(sys.version[:3])
 if pyversion < 3.6:
     sys.exit('fast-autocomplete requires Python 3.6 or later.')
+
+__version__ = pkg_resources.get_distribution("fast-autocomplete").version
 
 from fast_autocomplete.dwg import AutoComplete
 from fast_autocomplete.draw import DrawGraphMixin

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ flake8==3.5.0
 pygraphviz==1.3.1
 pytest==4.3.0
 pytest_cov==2.6.1
+bump2version==0.5.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,17 @@
+[bumpversion]
+current_version = 0.4.0
+commit = True
+tag = True
+tag_name = {new_version}
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:README.md]
+
 [flake8]
 max-line-length = 120
 builtins = json
 statistics = true
 ignore = E202
 exclude = ./data,./src,./tests,.svn,CVS,.bzr,.hg,.git,__pycache__,./venv
+

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,6 @@
-import re
 from setuptools import setup, find_packages
 
-VERSIONFILE = "fast_autocomplete/__init__.py"
-with open(VERSIONFILE, "r") as the_file:
-    verstrline = the_file.read()
-VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
-mo = re.search(VSRE, verstrline, re.M)
-if mo:
-    verstr = mo.group(1)
-else:
-    raise RuntimeError("Unable to find version string in %s." % (VERSIONFILE,))
+version = '0.4.0'
 
 
 def get_reqs(filename):
@@ -36,7 +27,7 @@ setup(
     url='https://github.com/wearefair/fast-autocomplete',
     download_url='https://github.com/wearefair/fast-autocomplete/tarball/master',
     author_email='sepd@fair.com',
-    version=verstr,
+    version=version,
     install_requires=reqs,
     dependency_links=[],
     packages=find_packages(exclude=('tests', 'docs')),


### PR DESCRIPTION
Help keep versions in sync across the project. This will ensure we have
the README and setup.py and __init__.py files in sync with the git tag.

Release process is now documented in the README.

```
$ python setup.py install
$ python -c "import fast_autocomplete; print(fast_autocomplete.__version__)"
0.4.0
```